### PR TITLE
Expand allowed versions of intouch/newrelic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "intouch/newrelic": "1.0.2",
+        "intouch/newrelic": "~1.0",
         "silex/silex": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
1.0.0-1.0.3 are fully compatible with this extension.  Furthermore, because of SemVer, all 1.x releases must be backwards compatible.