### PR TITLE
Don't report client errors (HTTP 4xx) to New Relic

### DIFF
--- a/src/NewRelic/Silex/NewRelicServiceProvider.php
+++ b/src/NewRelic/Silex/NewRelicServiceProvider.php
@@ -114,6 +114,13 @@ class NewRelicServiceProvider implements ServiceProviderInterface
         });
         
         $app->error(function (\Exception $e) use ($app) {
+            if ($e instanceof \Symfony\Component\HttpKernel\Exception\HttpException) {
+                if ($e->getStatusCode() >= 400 && $e->getStatusCode() < 500) {
+                    // Ignore client-side errors
+                    return;
+                }
+            }
+
             $app['newrelic']->noticeError($e->getMessage(), $e);
         });
     }


### PR DESCRIPTION
This integration currently reports all instances of `\Symfony\Component\HttpKernel\Exception\HttpException` to New Relic, including HTTP 4xx errors which are caught and handled by Silex/Symfony:

 - 403 Forbidden
 - 404 Not Found
 - Others

If a client is requesting pages which do not exist, this creates "false alarms" in New Relic which can then trigger alerts to site admins.  However, all of these are due to errors on the client's end, so it doesn't make sense for them to be logged in New Relic as application errors.